### PR TITLE
[ Strict mode ]

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,8 @@ Always the longer side is used to decide on resize ratio.
 Array of allowed extensions (e.g. `['jpg', 'jpeg', 'png']`). If specified and an input file has different extension the
 `imageSelected` event is fired with the error field set to 'Extension Not Allowed'. `dataUrl` and `resize` not calculated
 at all.
+
+## property: `[strictMode]`
+Boolean value that shows if the allowed extension can be considered at any cases of its symbols (e.g. `['jpg', 'png']`
+are allowed extensions, but with `strictMode === false` image with extensions like jPg, PNG and etc. can be uploaded 
+too). By default, the value of this input is equal to `true`

--- a/src/image-upload.directive.ts
+++ b/src/image-upload.directive.ts
@@ -15,6 +15,7 @@ export class ImageUploadDirective {
 
     @Input() resizeOptions: ResizeOptions;
     @Input() allowedExtensions: string[];
+    @Input() strictMode: boolean = true;
 
     constructor(private _elementref: ElementRef, private _renderer: Renderer) {
     }
@@ -27,6 +28,11 @@ export class ImageUploadDirective {
                 url: URL.createObjectURL(file)
             };
             let ext: string = file.name.split('.').pop();
+
+            if (!this.strictMode) {
+                ext = ext.toLowerCase();
+            }
+
             if (this.allowedExtensions && this.allowedExtensions.length && this.allowedExtensions.indexOf(ext) === -1) {
                 result.error = 'Extension Not Allowed';
                 this.imageSelected.emit(result);


### PR DESCRIPTION
Added ability to upload images with extensions that have different kind of cases of their symbols: additional input called strictMode that has value true by default so it will not affect current usage if no strictMode input was included